### PR TITLE
Add basic README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Radio Monorepo
+
+This repository contains a small streaming setup with two applications managed in a pnpm/Turbo monorepo:
+
+- **`apps/frontend`** – a React web client built with Vite.
+- **`apps/stream`** – a Bun based server that exposes an HLS stream and a WebSocket endpoint for listener counts.
+
+## Requirements
+
+- Node.js and pnpm
+- Bun
+- Docker (for the optional RTMP server)
+
+Install dependencies from the repository root:
+
+```bash
+pnpm install
+```
+
+## Running the applications
+
+### Frontend
+
+Start the development server:
+
+```bash
+pnpm --filter @radio/frontend dev
+```
+
+Build for production:
+
+```bash
+pnpm --filter @radio/frontend build
+```
+
+### Stream server
+
+Run the Bun server in development mode:
+
+```bash
+pnpm --filter @radio/stream dev
+```
+
+Start the local RTMP/HLS Docker container (required for streaming input):
+
+```bash
+pnpm --filter @radio/stream rtmp:dev
+```
+
+The RTMP container exposes port `1935` for incoming streams and serves generated HLS segments on port `8069`.
+
+The Bun server reads configuration from an `.env` file and listens on `PORT` (defaults to `8888`).
+
+

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,0 +1,32 @@
+# Frontend
+
+This directory contains the Vite powered React client.
+
+## Install dependencies
+
+From the repository root run:
+
+```bash
+pnpm install
+```
+
+## Development
+
+Copy the provided environment file and start the server:
+
+```bash
+cp .env.example .env
+pnpm dev
+```
+
+The app will be available on <http://localhost:5173> by default.
+
+## Build
+
+Create an optimized production bundle with:
+
+```bash
+pnpm build
+```
+
+

--- a/apps/stream/README.md
+++ b/apps/stream/README.md
@@ -1,0 +1,31 @@
+# Stream Server
+
+Bun service that provides a WebSocket endpoint and serves the HLS stream.
+
+## Environment
+
+Create a `.env` file in this directory:
+
+```bash
+PORT=8888 # HTTP port for the Bun server
+```
+
+## Development
+
+Start the Bun server with hot reload:
+
+```bash
+pnpm dev
+```
+
+### Local RTMP server
+
+For local streaming you can launch an RTMP server via Docker:
+
+```bash
+pnpm rtmp:dev
+```
+
+This exposes port `1935` for incoming streams and port `8069` for the generated HLS output.
+
+


### PR DESCRIPTION
## Summary
- document monorepo purpose and commands in root README
- add usage instructions for the Vite frontend
- add setup details for the Bun stream server

## Testing
- `pnpm test` *(fails: Error when performing the request to registry)*
- `pnpm lint` *(fails: Error when performing the request to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68403611e75883208164e260dbf9fe3e