### PR TITLE
Add reusable WebSocket service

### DIFF
--- a/apps/frontend/src/services/socket.ts
+++ b/apps/frontend/src/services/socket.ts
@@ -1,0 +1,15 @@
+import { socketUrl } from './env';
+
+let socket: WebSocket | null = null;
+
+export const getSocket = () => {
+  if (!socket || socket.readyState === WebSocket.CLOSED) {
+    socket = new WebSocket(socketUrl);
+  }
+  return socket;
+};
+
+export const closeSocket = () => {
+  socket?.close();
+  socket = null;
+};


### PR DESCRIPTION
## Summary
- introduce `getSocket` helper for a single WebSocket instance
- refactor `useSocket` hook to reuse connection

## Testing
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684036468b008320aa09936ce2bd590a