### PR TITLE
Add vinyl library tab

### DIFF
--- a/apps/frontend/src/features/index.ts
+++ b/apps/frontend/src/features/index.ts
@@ -1,2 +1,3 @@
 export * from './radio';
 export * from './chat';
+export * from './library';

--- a/apps/frontend/src/features/library.tsx
+++ b/apps/frontend/src/features/library.tsx
@@ -1,0 +1,27 @@
+import type React from 'react';
+
+const albums = [
+  { id: 1, title: 'Classics Vol. 1', cover: '/placeholder.png' },
+  { id: 2, title: 'Classics Vol. 2', cover: '/placeholder.png' },
+  { id: 3, title: 'Golden Hits', cover: '/placeholder.png' },
+  { id: 4, title: 'Retro Wave', cover: '/placeholder.png' },
+  { id: 5, title: 'Rock Legends', cover: '/placeholder.png' },
+  { id: 6, title: 'Jazz Moods', cover: '/placeholder.png' },
+];
+
+export const Library: React.FC = () => {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 gap-4 overflow-y-auto max-h-[500px] p-1">
+      {albums.map((album) => (
+        <div key={album.id} className="flex flex-col items-center">
+          <img
+            src={album.cover}
+            alt={album.title}
+            className="w-full rounded shadow-md"
+          />
+          <span className="mt-1 text-sm text-center">{album.title}</span>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/apps/frontend/src/features/radio.tsx
+++ b/apps/frontend/src/features/radio.tsx
@@ -2,10 +2,13 @@ import type React from 'react';
 import { useSocket } from '@/hooks/useSocket';
 import { useStream } from '@/hooks/useStream';
 import { Chat } from './chat';
+import { Library } from './library';
+import { useState } from 'react';
 
 export const Radio: React.FC = () => {
   const { videoRef, streamAvailable } = useStream();
   const listeners = useSocket();
+  const [tab, setTab] = useState<'chat' | 'library'>('chat');
 
   return (
     <div className="min-h-screen w-full bg-neutral-900/50 flex flex-col items-center justify-center text-neutral-100 p-4">
@@ -36,7 +39,21 @@ export const Radio: React.FC = () => {
           </div>
         </div>
         <div className="w-full md:w-80">
-          <Chat />
+          <div className="mb-2 flex justify-center gap-2">
+            <button
+              onClick={() => setTab('chat')}
+              className={`px-3 py-1 rounded-md text-sm font-semibold ${tab === 'chat' ? 'bg-moss text-white' : 'bg-neutral-700 text-white/70'}`}
+            >
+              Chat
+            </button>
+            <button
+              onClick={() => setTab('library')}
+              className={`px-3 py-1 rounded-md text-sm font-semibold ${tab === 'library' ? 'bg-moss text-white' : 'bg-neutral-700 text-white/70'}`}
+            >
+              Library
+            </button>
+          </div>
+          {tab === 'chat' ? <Chat /> : <Library />}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add Library feature with placeholder albums displayed in a grid
- switch between Chat and Library in Radio with simple tabs

## Testing
- `pnpm test` *(fails: request to registry - no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6840669f64648320aa956fcb4d3b8a61