### PR TITLE
Add frontend PWA setup

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/logo.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#000000" />
     <title>Вінілове Радіо</title>
   </head>
   <body>

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -52,6 +52,7 @@
     "typescript": "5.6.3",
     "vite": "5.4.9",
     "vite-plugin-mkcert": "1.17.6",
+    "vite-plugin-pwa": "0.18.3",
     "vite-tsconfig-paths": "5.0.1",
     "vitest": "^2.1.3",
     "zustand": "^5.0.3"

--- a/apps/frontend/public/manifest.webmanifest
+++ b/apps/frontend/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "Вінілове Радіо",
+  "short_name": "Radio",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { RouterProvider } from '@tanstack/react-router';
 import { queryClient } from '@/services/api';
 import router from '@/router';
 import '@/styles/tailwind.css';
+import { registerSW } from 'virtual:pwa-register';
 
 const container = document.getElementById('root') as HTMLElement;
 const root = createRoot(container);
@@ -16,3 +17,5 @@ root.render(
     </QueryClientProvider>
   </StrictMode>,
 );
+
+registerSW();

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -2,6 +2,7 @@
 
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
+import { VitePWA } from 'vite-plugin-pwa';
 // import mkcert from 'vite-plugin-mkcert';
 import tsPaths from 'vite-tsconfig-paths';
 
@@ -16,6 +17,30 @@ export default defineConfig({
     //   source: 'coding',
     // }),
     tsPaths(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      includeAssets: ['favicon.png', 'logo.png'],
+      manifest: {
+        name: 'Вінілове Радіо',
+        short_name: 'Radio',
+        start_url: '.',
+        display: 'standalone',
+        background_color: '#ffffff',
+        theme_color: '#000000',
+        icons: [
+          {
+            src: '/logo.png',
+            sizes: '192x192',
+            type: 'image/png',
+          },
+          {
+            src: '/logo.png',
+            sizes: '512x512',
+            type: 'image/png',
+          },
+        ],
+      },
+    }),
   ],
   build: {
     cssMinify: 'lightningcss',


### PR DESCRIPTION
## Summary
- add vite-plugin-pwa to frontend
- create manifest
- register service worker
- link manifest in `index.html`

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6840eb3e64748320a1f8f484b247859e